### PR TITLE
fix(dvd_json): remove extra colon from cell filesize

### DIFF
--- a/dvd_json.c
+++ b/dvd_json.c
@@ -172,7 +172,7 @@ void dvd_json(struct dvd_info dvd_info, struct dvd_track dvd_tracks[], uint16_t 
 				printf("         \"msecs\": %" PRIu32 ",\n", dvd_cell.msecs);
 				printf("         \"first sector\": %" PRIu64 ",\n", dvd_cell.first_sector);
 				printf("         \"last sector\": %" PRIu64 ",\n", dvd_cell.last_sector);
-				printf("         \"filesize:\": %" PRIu64 "\n", dvd_cell.filesize);
+				printf("         \"filesize\": %" PRIu64 "\n", dvd_cell.filesize);
 				printf("       }");
 
 				if(c  + 1 < dvd_track.cells)


### PR DESCRIPTION
The property name for `cell[].filesize` has a trailing colon

```diff
-filesize:
+filesize
```