### PR TITLE
don't ignore last block in every cell

### DIFF
--- a/dvd_cell.c
+++ b/dvd_cell.c
@@ -51,11 +51,7 @@ uint64_t dvd_cell_blocks(ifo_handle_t *vmg_ifo, ifo_handle_t *vts_ifo, uint16_t 
 	last_sector = dvd_cell_last_sector(vmg_ifo, vts_ifo, track_number, cell_number);
 
 	uint64_t blocks = 0;
-	blocks = last_sector - first_sector;
-
-	// Include the last cell
-	if(last_sector == first_sector)
-		blocks++;
+	blocks = last_sector - first_sector + 1;
 
 	return blocks;
 

--- a/dvd_copy.c
+++ b/dvd_copy.c
@@ -539,8 +539,7 @@ int main(int argc, char **argv) {
 
 			cell_block = dvd_cell.first_sector;
 
-			// This is where you would change the boundaries -- are you dumping to a track file (no boundaries) or a VOB (boundaries)
-			while(cell_block < dvd_cell.last_sector) {
+			while(cell_block <= dvd_cell.last_sector) {
 
 				cell_blocks_read = DVDReadBlocks(dvdread_vts_file, (size_t)cell_block, 1, dvd_copy.buffer);
 


### PR DESCRIPTION
The block ranges for dvd cells are inclusive, so always include the last block when extracting.

closes: #5 