### PR TITLE
fix(dvd_rip): Include missing header

### DIFF
--- a/dvd_rip.c
+++ b/dvd_rip.c
@@ -10,6 +10,7 @@
 #ifdef __linux__
 #include <linux/cdrom.h>
 #include <linux/limits.h>
+#include <sys/sysinfo.h>
 #include "dvd_drive.h"
 #else
 #include <limits.h>


### PR DESCRIPTION
that provides `get_nprocs` on Linux systems. The header was previously removed in 5ec58426 for compatibility on FreeBSD systems.